### PR TITLE
Displayed sort fields, Advanced search option

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,11 +5,17 @@ Name: nswdpc-search-elasticsearch
 nglasl\extensible\ExtensibleSearchPage:
   custom_search_engines:
     Symbiote\ElasticSearch\ElasticaSearchEngine: 'Elastic'
+  extensions:
+    - 'NSWDPC\Search\ExtensibleSearchPageExtension'
 
 nglasl\extensible\ExtensibleSearchSuggestion:
   enable_suggestions: true
 
 # add extensions to controllers
+nglasl\extensible\ExtensibleSearchPageController:
+  extensions:
+    - 'NSWDPC\Search\ExtensibleSearchPageControllerExtension'
+
 PageController:
   extensions:
     - 'nglasl\extensible\ExtensibleSearchExtension'

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "heyday/silverstripe-elastica": "^2.2",
         "nglasl/silverstripe-extensible-search": "^4.1",
         "nyeholt/silverstripe-extensible-elastic": "^2.10.0",
-        "nswdpc/silverstripe-elemental-extensible-search": "^0.1"
+        "nswdpc/silverstripe-elemental-extensible-search": "^0.1",
+        "symbiote/silverstripe-multivaluefield": "^5.1.0"
     },
     "config": {
         "process-timeout": 600

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,5 @@
+en:
+  nswdpc_searchboilerplate:
+    SORT_FIELD_LASTEDITED: 'Last updated'
+    SORT_FIELD__SCORE: 'Relevance'
+    SORT_FIELD_TITLE: 'Title'

--- a/src/Extensions/ExtensibleSearchPageControllerExtension.php
+++ b/src/Extensions/ExtensibleSearchPageControllerExtension.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace NSWDPC\Search;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormField;
+
+/**
+ * Update search form based on configuration
+ * Extension applied to nglasl\extensible\ExtensibleSearchPageController
+ * @author James
+ */
+class ExtensibleSearchPageControllerExtension extends Extension
+{
+
+    /**
+     * Return the sort by fields configured as an array
+     * The key is the field name, the value is a configured label, applied as the default in an i18n string value
+     */
+    public function getDisplayedSortFields() : array {
+        $sortFields = [];
+        $page = $this->owner->data();
+        if($displayedSortByFields = $page->DisplayedSortFields) {
+            $selectableSortFields = $page->getSelectableFields();
+            $displayedFields = $displayedSortByFields->getValue();
+            foreach($displayedFields as $fieldName) {
+                $fieldLabel = isset($selectableSortFields[ $fieldName ]) ? FormField::name_to_label($selectableSortFields[ $fieldName ]) : '';
+                if(!$fieldLabel) {
+                    $fieldLabel = FormField::name_to_label($fieldName);
+                }
+                $sortFields[ $fieldName ] = _t(
+                    'nswdpc_searchboilerplate.SORT_FIELD_' . strtoupper($fieldName),
+                    $fieldLabel
+                );
+            }
+        }
+        return $sortFields;
+    }
+
+    /**
+     * Apply configured fields for sorting to the form
+     * @param Form $form
+     */
+    public function applySortByFields(Form $form) {
+        $sortField = $form->Fields()->dataFieldByName('SortBy');
+        if($sortField) {
+            $fields = $this->getDisplayedSortFields();
+            if(count($fields) == 0) {
+                // remove fields as there is no displayed sort
+                $form->Fields()->removeByName(['SortBy','SortDirection']);
+            } else {
+                $sortField->setSource($fields);
+            }
+        }
+    }
+
+    /**
+     * Update the form
+     * @param Form $form
+     */
+    public function updateExtensibleSearchForm(Form $form)
+    {
+        $this->applySortByFields($form);
+    }
+
+    /**
+     * Update the search form
+     * @param Form $form
+     */
+    public function updateExtensibleSearchSearchForm(Form $form) {
+        $this->applySortByFields($form);
+    }
+}

--- a/src/Extensions/ExtensibleSearchPageExtension.php
+++ b/src/Extensions/ExtensibleSearchPageExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace NSWDPC\Search;
+
+use SilverStripe\ORM\DataExtension;
+use Symbiote\MultiValueField\Fields\MultiValueDropdownField;
+
+/**
+ * Update search form based on configuration
+ * Extension applied to nglasl\extensible\ExtensibleSearchPageController
+ * @author James
+ */
+class ExtensibleSearchPageExtension extends DataExtension
+{
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'DisplayedSortFields' => 'MultiValueField'
+    ];
+
+    /**
+     * Apply selectable sort fields to the displayed sort fields
+     */
+    public function updateExtensibleSearchPageCMSFields(&$fields) {
+        $sortByField = $fields->dataFieldByName('SortBy');
+        if($sortByField) {
+            $displayedSortByField = MultiValueDropdownField::create(
+                'DisplayedSortFields',
+                _t(
+                    'nswdpc_searchboilerplate.DISPLAYED_SORT_FIELDS',
+                    'Displayed sort fields'
+                ),
+                $sortByField->getSource()
+            );
+            $fields->insertAfter('SortBy', $displayedSortByField);
+        } else {
+            $fields->removeByName('DisplayedSortFields');
+        }
+    }
+
+}

--- a/src/Extensions/ExtensibleSearchPageExtension.php
+++ b/src/Extensions/ExtensibleSearchPageExtension.php
@@ -2,6 +2,7 @@
 
 namespace NSWDPC\Search;
 
+use SilverStripe\Forms\CheckboxField;
 use SilverStripe\ORM\DataExtension;
 use Symbiote\MultiValueField\Fields\MultiValueDropdownField;
 
@@ -17,26 +18,60 @@ class ExtensibleSearchPageExtension extends DataExtension
      * @var array
      */
     private static $db = [
-        'DisplayedSortFields' => 'MultiValueField'
+        'DisplayedSortFields' => 'MultiValueField',
+        'UseAdvancedSearch' => 'Boolean'
+    ];
+
+    /**
+     * @var array
+     */
+    private static $defaults = [
+        'UseAdvancedSearch' => 0
     ];
 
     /**
      * Apply selectable sort fields to the displayed sort fields
      */
     public function updateExtensibleSearchPageCMSFields(&$fields) {
-        $sortByField = $fields->dataFieldByName('SortBy');
-        if($sortByField) {
-            $displayedSortByField = MultiValueDropdownField::create(
-                'DisplayedSortFields',
-                _t(
-                    'nswdpc_searchboilerplate.DISPLAYED_SORT_FIELDS',
-                    'Displayed sort fields'
-                ),
-                $sortByField->getSource()
+
+        if($this->owner->SearchEngine) {
+
+            // set to use advanced search
+            $fields->insertBefore(
+                'SortBy',
+                CheckboxField::create(
+                    'UseAdvancedSearch',
+                    _t(
+                        'nswdpc_searchboilerplate.USE_ADVANCED_SEARCH',
+                        'Use advanced search'
+                    )
+                )->setDescription(
+                    _t(
+                        'nswdpc_searchboilerplate.USE_ADVANCED_SEARCH_DESCRIPTION',
+                        'Show filters next to the search results'
+                    )
+                )
             );
-            $fields->insertAfter('SortBy', $displayedSortByField);
+
+            // add sort fields that can be displayed
+            if($sortByField = $fields->dataFieldByName('SortBy')) {
+                $fields->insertAfter(
+                    'SortBy',
+                    MultiValueDropdownField::create(
+                        'DisplayedSortFields',
+                        _t(
+                            'nswdpc_searchboilerplate.DISPLAYED_SORT_FIELDS',
+                            'Displayed sort fields'
+                        ),
+                        $sortByField->getSource()
+                    )
+                );
+            } else {
+                $fields->removeByName(['DisplayedSortFields']);
+            }
+
         } else {
-            $fields->removeByName('DisplayedSortFields');
+            $fields->removeByName(['DisplayedSortFields','UseAdvancedSearch']);
         }
     }
 


### PR DESCRIPTION
## Changes

+ Add language strings for selectable field names showing in Sort By on frontend
+ New: add Use Advanced Search to allow projects to toggle between keyword or detailed filtered search interface
+ New: add DisplayedSortFields - allow an editor to choose which fields should be displayed in the Sort By interface. If none, SortBy and SortDirection fields are removed