### PR TITLE
Fix: form can be null

### DIFF
--- a/src/Extensions/ExtensibleSearchPageControllerExtension.php
+++ b/src/Extensions/ExtensibleSearchPageControllerExtension.php
@@ -66,9 +66,11 @@ class ExtensibleSearchPageControllerExtension extends Extension
 
     /**
      * Update the search form
-     * @param Form $form
+     * @param Form|null $form
      */
-    public function updateExtensibleSearchSearchForm(Form $form) {
-        $this->applySortByFields($form);
+    public function updateExtensibleSearchSearchForm(?Form $form) {
+        if($form) {
+            $this->applySortByFields($form);
+        }
     }
 }


### PR DESCRIPTION
## Changes

+ Handle when form value passed to `updateExtensibleSearchSearchForm` is null